### PR TITLE
Movido callInterfaceFunctions para a grid

### DIFF
--- a/src/component/action/action.php
+++ b/src/component/action/action.php
@@ -197,7 +197,7 @@ class Action extends \Component\Component
      */
     public function mountButtonGrid($line = null)
     {
-        $modelId = $this->getModel()->getValue($this->getModel()->getPrimaryKey());
+        $modelId = $this->getPk();
         $link = new \View\Ext\LinkButton('action-link-' . $this->getId() . '-' . $modelId, $this->getIcon(), null, $this->getParsedUrl());
         $link->setData('model-id', $modelId);
         $link->setClass('pkColumnEdit');

--- a/src/component/grid/grid.php
+++ b/src/component/grid/grid.php
@@ -90,7 +90,7 @@ class Grid extends \Component\Component
      *
      * @var boolean
      */
-    protected $callInterfaceFunctions = TRUE;
+    protected $callInterfaceFunctions = FALSE;
 
     /**
      * Construct a grid

--- a/src/component/grid/grid.php
+++ b/src/component/grid/grid.php
@@ -85,6 +85,14 @@ class Grid extends \Component\Component
     protected $actions;
 
     /**
+     * Call interface functions.
+     * Used for optimizations
+     *
+     * @var boolean
+     */
+    protected $callInterfaceFunctions = TRUE;
+
+    /**
      * Construct a grid
      *
      * @param string $id
@@ -182,6 +190,16 @@ class Grid extends \Component\Component
         $this->title = $title;
 
         return $this;
+    }
+
+    public function getCallInterfaceFunctions()
+    {
+        return $this->callInterfaceFunctions;
+    }
+
+    public function setCallInterfaceFunctions($callInterfaceFunctions)
+    {
+        $this->callInterfaceFunctions = $callInterfaceFunctions;
     }
 
     /**
@@ -1154,11 +1172,6 @@ class Grid extends \Component\Component
         {
             return new \View\Div(null, 'Impossível encontrar registro.');
         }
-    }
-
-    public function getCallInterfaceFunctions()
-    {
-        return false;
     }
 
 }

--- a/src/component/grid/searchgrid.php
+++ b/src/component/grid/searchgrid.php
@@ -13,14 +13,6 @@ class SearchGrid extends \Component\Grid\Grid
 {
 
     /**
-     * Call interface functions.
-     * Used for optimizations
-     *
-     * @var boolean
-     */
-    protected $callInterfaceFunctions = TRUE;
-
-    /**
      * Extra filters
      * @var array
      */
@@ -532,16 +524,6 @@ class SearchGrid extends \Component\Grid\Grid
         }
 
         return $tabItem;
-    }
-
-    public function getCallInterfaceFunctions()
-    {
-        return $this->callInterfaceFunctions;
-    }
-
-    public function setCallInterfaceFunctions($callInterfaceFunctions)
-    {
-        $this->callInterfaceFunctions = $callInterfaceFunctions;
     }
 
     protected function createTd(\Component\Grid\Column $column, $index, $item, $tr)

--- a/src/component/grid/searchgrid.php
+++ b/src/component/grid/searchgrid.php
@@ -59,6 +59,8 @@ class SearchGrid extends \Component\Grid\Grid
             $this->setColumns($columns);
         }
 
+        $this->setCallInterfaceFunctions(true);
+
         $this->setCreateAllTabs();
     }
 

--- a/src/db/model.php
+++ b/src/db/model.php
@@ -564,7 +564,7 @@ class Model implements \JsonSerializable
      * If not find create anotger
      *
      * @param type $id
-     * @return \Db\name
+     * @return \Db\Model
      */
     public static function findOneByPkOrCreate($id = null, $logId = null)
     {


### PR DESCRIPTION
A page utiliza a função getCallInterfaceFunctions(), então é necessário o valor correto na grid.
Movida a variável da searchgrid para a grid.